### PR TITLE
assert Montgomery modulus == Barrett modulus

### DIFF
--- a/include/nil/crypto3/multiprecision/modular/modular_params.hpp
+++ b/include/nil/crypto3/multiprecision/modular/modular_params.hpp
@@ -87,7 +87,11 @@ namespace nil {
                 }
 
                 number_type get_mod() const {
-                    return backends::montgomery_params<Backend>::mod() | backends::barrett_params<Backend>::mod();
+                    BOOST_ASSERT(backends::montgomery_params<Backend>::mod() == backends::barrett_params<Backend>::mod() || (backends::montgomery_params<Backend>::mod() + backends::barrett_params<Backend>::mod() > 0 && backends::montgomery_params<Backend>::mod() * backends::barrett_params<Backend>::mod() == 0));
+                    if (backends::montgomery_params<Backend>::mod() > 0)
+                        return backends::montgomery_params<Backend>::mod();
+                    else
+                        return backends::barrett_params<Backend>::mod();
                 }
 
                 template<typename BackendT, expression_template_option ExpressionTemplates>


### PR DESCRIPTION
correct me if this is wrong, but it looks like bitwise OR in get_mod() will return invalid modulus if they are both initialized but they differ.

it might be valid for only one of the params to be initialized, in the case where the developer knows which one they will use because they supply a fixed modulus and skip initializing the modular reduction params that are never used.

shown here is an ASSERT for equality, or else one modulus must be zero and the other must be non-zero.

proposed code has not been tested.

note: style violation failing to insert braces { } in the if - else statement.