### PR TITLE
Remove duplicated BOOST Traits class templates

### DIFF
--- a/include/nil/crypto3/multiprecision/cpp_int.hpp
+++ b/include/nil/crypto3/multiprecision/cpp_int.hpp
@@ -144,57 +144,6 @@ namespace nil {
                                                 (SignType == unsigned_magnitude) || (SignType == unsigned_packed)> { };
 
             namespace backends {
-                //
-                // Traits class determines whether T should be implicitly convertible to U, or
-                // whether the constructor should be made explicit.  The latter happens if we
-                // are losing the sign, or have fewer digits precision in the target type:
-                //
-                template<class T, class U>
-                struct is_implicit_cpp_int_conversion;
-
-                template<unsigned MinBits,
-                         unsigned MaxBits,
-                         cpp_integer_type SignType,
-                         cpp_int_check_type Checked,
-                         class Allocator,
-                         unsigned MinBits2,
-                         unsigned MaxBits2,
-                         cpp_integer_type SignType2,
-                         cpp_int_check_type Checked2,
-                         class Allocator2>
-                struct is_implicit_cpp_int_conversion<
-                    cpp_int_backend<MinBits, MaxBits, SignType, Checked, Allocator>,
-                    cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2>> {
-                    using t1 = cpp_int_backend<MinBits, MaxBits, SignType, Checked, Allocator>;
-                    using t2 = cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2>;
-                    static constexpr const bool value = (is_signed_number<t2>::value || !is_signed_number<t1>::value) &&
-                                                        (max_precision<t1>::value <= max_precision<t2>::value);
-                };
-
-                //
-                // Traits class to determine whether operations on a cpp_int may throw:
-                //
-                template<class T>
-                struct is_non_throwing_cpp_int : public std::integral_constant<bool, false> { };
-                template<unsigned MinBits, unsigned MaxBits, cpp_integer_type SignType>
-                struct is_non_throwing_cpp_int<cpp_int_backend<MinBits, MaxBits, SignType, unchecked, void>>
-                    : public std::integral_constant<bool, true> { };
-
-                //
-                // Traits class, determines whether the cpp_int is fixed precision or not:
-                //
-                template<class T>
-                struct is_fixed_precision;
-                template<unsigned MinBits,
-                         unsigned MaxBits,
-                         cpp_integer_type SignType,
-                         cpp_int_check_type Checked,
-                         class Allocator>
-                struct is_fixed_precision<cpp_int_backend<MinBits, MaxBits, SignType, Checked, Allocator>>
-                    : public std::integral_constant<
-                          bool,
-                          max_precision<cpp_int_backend<MinBits, MaxBits, SignType, Checked, Allocator>>::value !=
-                              UINT_MAX> { };
 
                 namespace detail {
 


### PR DESCRIPTION
This is in the form of a question -- as I work to understand more completely the preferred implementation and structure for type_traits and Trait templates in crypto3, it becomes clear that remaining dependent on BOOST and extending BOOST makes more sense than duplicating BOOST.

Can we revise the architecture of crypto3 (over time, naturally) to prefer the intended design of BOOST with custom extensions added to its templates and types, so that there is minimal copying of code and maximal native compatibility with BOOST?

A big factor in my decision whether to use crypto3 at all is whether it causes confusion when I build it into my existing project where BOOST is already being used. If the current design of crypto3 intends for me to swap out boost::multiprecision for crypto3::multiprecision instead, and then rebuild my project hoping that I don't have any system paths pointing to BOOST libraries where the wrong version might keep popping up again anyway, then I can maybe adapt to that code maintenance challenge, but if there are large numbers of lines of code copied from BOOST and relocated to other namespaces unique to crypto3 and I will ALSO have my entire BOOST library source code and my own lines that rely on BOOST namespaces, templates and types, then that is much more difficult to accept -- for the simple reason that when I search for a keyword in my project and it relates to lines that were copied from BOOST, it is likely that I will see search results from all three sources, when what I want to see is only crypto3 and my own source code which depends on crypto3, with the smallest number of overlapping incidental search results due to generic terminology that always ends up being present everywhere due to common design patterns, naming conventions, and English as the first language of software engineering.

I recognize, if the answer to my question above is "Yes," that a large number of lines of duplicated BOOST code currently in crypto3 will need to be deleted, as I am showing with this pull request. For every deletion, a change of namespace or a scope resolution operator will be required, to fix up the lines of crypto3 source code that were expecting crypto3:: to contain the deleted duplicated template or type.

Considering that BOOST already provides the Trait templates that I show being deleted, my belief is that BOOST, and not crypto3, should be the library that provides them. This is especially relevant for any code that will ever need to be improved, enhanced, or just better-documented, because those changes need to be made in the BOOST library where they do the most good for the most developers, and in addition to ensuring that the development of crypto3 continues to improve the BOOST library from which it was created, the crypto3 library should not miss out on those improvements that other developers make to BOOST over time.