### PR TITLE
inline of window_bits to prevent multiple symbols during linking

### DIFF
--- a/include/nil/crypto3/multiprecision/modular/modular_adaptor.hpp
+++ b/include/nil/crypto3/multiprecision/modular/modular_adaptor.hpp
@@ -392,7 +392,7 @@ namespace nil {
                     result = val;
                 }
 
-                size_t window_bits(size_t exp_bits) {
+                inline size_t window_bits(size_t exp_bits) {
                     BOOST_STATIC_CONSTEXPR size_t wsize_count = 6;
                     BOOST_STATIC_CONSTEXPR size_t wsize[wsize_count][2] = {{1434, 7}, {539, 6}, {197, 4},
                                                                            {70, 3},   {17, 2},  {0, 0}};


### PR DESCRIPTION
This shows up when creating a class for an ECSDA key pair and then writing a test that uses that class.

This function will make the linker break with multiple symbols and so, I 'inlined' it.  I'm sure there are going to be others as I proceed.